### PR TITLE
fix escaping and upgrade encoding

### DIFF
--- a/FDF.php
+++ b/FDF.php
@@ -130,8 +130,8 @@ class FDF
     private static function smartEncode($s) {
         $utf16= mb_convert_encoding($s, 'UTF-16BE');
         $safe= $utf16;
-        $safe= mb_eregi_replace('\\x00\)', '\x00\\\)', $safe);
-        $safe= mb_eregi_replace('\\x00\(', '\x00\\\(', $safe);
+        $safe= mb_eregi_replace('\)', '\\)', $safe);
+        $safe= mb_eregi_replace('\(', '\\(', $safe);
         return pack("n",0xFEFF) . $safe;
     }
 }

--- a/FDF.php
+++ b/FDF.php
@@ -132,6 +132,7 @@ class FDF
         $safe= $utf16;
         $safe= mb_eregi_replace('\)', '\\)', $safe);
         $safe= mb_eregi_replace('\(', '\\(', $safe);
+        $safe= mb_eregi_replace('\\\\', '\\\\\\', $safe);
         return pack("n",0xFEFF) . $safe;
     }
 }

--- a/FDF.php
+++ b/FDF.php
@@ -117,13 +117,18 @@ class FDF
 
     /**
      * Encode the string in UTF-16 BE, escaping the parens.
+     *
+     * UCS-2 should now be considered obsolete.
+     * It no longer refers to an encoding form in either 10646 or the Unicode Standard.
+     * https://www.ietf.org/rfc/rfc2781.txt
+     * https://en.wikipedia.org/wiki/UTF-16
      * 
      * @param s The string to be encoded.
      * 
      * @return The encoded string.
      */
     private static function smartEncode($s) {
-        $utf16= mb_convert_encoding($s, 'UCS-2');
+        $utf16= mb_convert_encoding($s, 'UTF-16BE');
         $safe= $utf16;
         $safe= mb_eregi_replace('\\x00\)', '\x00\\\)', $safe);
         $safe= mb_eregi_replace('\\x00\(', '\x00\\\(', $safe);

--- a/test.php
+++ b/test.php
@@ -4,7 +4,7 @@ $readonly= array();
 $hidden= array();
 
 $fields= array(
-    'Shipper'       => 'John Smith',
+    'Shipper'       => 'John Smith c\o Jane',
     'PO#'          => '800) 555-1234',
     'FXF Priority'  => true
 );

--- a/test.php
+++ b/test.php
@@ -5,7 +5,7 @@ $hidden= array();
 
 $fields= array(
     'Shipper'       => 'John Smith',
-    'PO#'          => '555-1234',
+    'PO#'          => '800) 555-1234',
     'FXF Priority'  => true
 );
 $fdf= new FDF($fields, $readonly, $hidden);


### PR DESCRIPTION
- although the existing parenthetical escaping was technically preventing a crash, it merely hid the characters as an invisible multibyte character
- there was no backslash escaping
- despite the comment for UTF-16BE, the antiquated UTC-2 was being used